### PR TITLE
Fix Labeler Issue #561 - HttpError Issue

### DIFF
--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -251,12 +251,14 @@ async function addLabels(
   labels: string[]
 ) {
   if (labels.length <= LABELS_LIMIT_TO_ADD_AT_ONCE) {
-      await sendLabels(client, prNumber, labels);
-      return;
+    await sendLabels(client, prNumber, labels);
+    return;
   }
 
   if (labels.length > ISSUE_LABELS_LIMIT) {
-    core.warning(`Labels limit exceeded. The maximum allowable number of labels is ${ISSUE_LABELS_LIMIT}. Only ${ISSUE_LABELS_LIMIT} labels will be added.`);
+    core.warning(
+      `Labels limit exceeded. The maximum allowable number of labels is ${ISSUE_LABELS_LIMIT}. Only ${ISSUE_LABELS_LIMIT} labels will be added.`
+    );
     labels.splice(ISSUE_LABELS_LIMIT);
   }
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -229,7 +229,10 @@ function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {
   return true;
 }
 
-async function addLabels(
+const ISSUE_LABELS_LIMIT = 100;
+const LABELS_LIMIT_TO_ADD_AT_ONCE = 48;
+
+async function sendLabels(
   client: ClientType,
   prNumber: number,
   labels: string[]
@@ -240,6 +243,28 @@ async function addLabels(
     issue_number: prNumber,
     labels: labels
   });
+}
+
+async function addLabels(
+  client: ClientType,
+  prNumber: number,
+  labels: string[]
+) {
+  if (labels.length <= LABELS_LIMIT_TO_ADD_AT_ONCE) {
+      await sendLabels(client, prNumber, labels);
+      return;
+  }
+
+  if (labels.length > ISSUE_LABELS_LIMIT) {
+    core.warning(`Labels limit exceeded. The maximum allowable number of labels is ${ISSUE_LABELS_LIMIT}. Only ${ISSUE_LABELS_LIMIT} labels will be added.`);
+    labels.splice(ISSUE_LABELS_LIMIT);
+  }
+
+  while (labels.length > 0) {
+    let labelsToAdd: string[] = [];
+    labelsToAdd = labels.splice(0, LABELS_LIMIT_TO_ADD_AT_ONCE);
+    await sendLabels(client, prNumber, labelsToAdd);
+  }
 }
 
 async function removeLabels(


### PR DESCRIPTION
**Description:**
The changes in this PR are meant to fix the issue in Labeler that throws `HttpError: Server Error` every time the number of labels being added exceeds a certain threshold (50+ as mentioned in the issue, but it seems to be even lower, at 48).

**Related issue:** https://github.com/actions/labeler/issues/561

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.