### PR TITLE
Implement the new structure of the match object for changed files section

### DIFF
--- a/__tests__/fixtures/all_options.yml
+++ b/__tests__/fixtures/all_options.yml
@@ -1,14 +1,17 @@
 label1:
   - any:
-      - changed-files: ['glob']
+      - changed-files:
+          - AnyGlobToAnyFile: ['glob']
       - head-branch: ['regexp']
       - base-branch: ['regexp']
   - all:
-      - changed-files: ['glob']
+      - changed-files:
+          - AllGlobsToAllFiles: ['glob']
       - head-branch: ['regexp']
       - base-branch: ['regexp']
 
 label2:
-  - changed-files: ['glob']
+  - changed-files:
+      - AnyGlobToAnyFile: ['glob']
   - head-branch: ['regexp']
   - base-branch: ['regexp']

--- a/__tests__/fixtures/any_and_all.yml
+++ b/__tests__/fixtures/any_and_all.yml
@@ -1,6 +1,8 @@
 tests:
   - any:
       - head-branch: ['^tests/', '^test/']
-      - changed-files: ['tests/**/*']
+      - changed-files:
+          - AnyGlobToAnyFile: ['tests/**/*']
   - all:
-      - changed-files: ['!tests/requirements.txt']
+      - changed-files:
+          - AllGlobsToAllFiles: ['!tests/requirements.txt']

--- a/__tests__/fixtures/only_pdfs.yml
+++ b/__tests__/fixtures/only_pdfs.yml
@@ -1,2 +1,3 @@
 touched-a-pdf-file:
-  - changed-files: ['*.pdf']
+  - changed-files:
+      - AnyGlobToAnyFile: ['*.pdf']

--- a/__tests__/labeler.test.ts
+++ b/__tests__/labeler.test.ts
@@ -29,14 +29,14 @@ describe('getLabelConfigMapFromObject', () => {
   expected.set('label1', [
     {
       any: [
-        {changedFiles: ['glob']},
+        {changedFiles: [{AnyGlobToAnyFile: ['glob']}]},
         {baseBranch: undefined, headBranch: ['regexp']},
         {baseBranch: ['regexp'], headBranch: undefined}
       ]
     },
     {
       all: [
-        {changedFiles: ['glob']},
+        {changedFiles: [{AllGlobsToAllFiles: ['glob']}]},
         {baseBranch: undefined, headBranch: ['regexp']},
         {baseBranch: ['regexp'], headBranch: undefined}
       ]
@@ -45,7 +45,7 @@ describe('getLabelConfigMapFromObject', () => {
   expected.set('label2', [
     {
       any: [
-        {changedFiles: ['glob']},
+        {changedFiles: [{AnyGlobToAnyFile: ['glob']}]},
         {baseBranch: undefined, headBranch: ['regexp']},
         {baseBranch: ['regexp'], headBranch: undefined}
       ]
@@ -61,12 +61,12 @@ describe('getLabelConfigMapFromObject', () => {
 describe('toMatchConfig', () => {
   describe('when all expected config options are present', () => {
     const config = {
-      'changed-files': ['testing-files'],
+      'changed-files': [{AnyGlobToAnyFile: ['testing-files']}],
       'head-branch': ['testing-head'],
       'base-branch': ['testing-base']
     };
     const expected: BaseMatchConfig = {
-      changedFiles: ['testing-files'],
+      changedFiles: [{AnyGlobToAnyFile: ['testing-files']}],
       headBranch: ['testing-head'],
       baseBranch: ['testing-base']
     };
@@ -89,7 +89,9 @@ describe('toMatchConfig', () => {
 
 describe('checkMatchConfigs', () => {
   describe('when a single match config is provided', () => {
-    const matchConfig: MatchConfig[] = [{any: [{changedFiles: ['*.txt']}]}];
+    const matchConfig: MatchConfig[] = [
+      {any: [{changedFiles: [{AnyGlobToAnyFile: ['*.txt']}]}]}
+    ];
 
     it('returns true when our pattern does match changed files', () => {
       const changedFiles = ['foo.txt', 'bar.txt'];
@@ -107,7 +109,12 @@ describe('checkMatchConfigs', () => {
 
     it('returns true when either the branch or changed files patter matches', () => {
       const matchConfig: MatchConfig[] = [
-        {any: [{changedFiles: ['*.txt']}, {headBranch: ['some-branch']}]}
+        {
+          any: [
+            {changedFiles: [{AnyGlobToAnyFile: ['*.txt']}]},
+            {headBranch: ['some-branch']}
+          ]
+        }
       ];
       const changedFiles = ['foo.txt', 'bar.txt'];
 
@@ -118,7 +125,7 @@ describe('checkMatchConfigs', () => {
 
   describe('when multiple MatchConfigs are supplied', () => {
     const matchConfig: MatchConfig[] = [
-      {any: [{changedFiles: ['*.txt']}]},
+      {any: [{changedFiles: [{AnyGlobToAnyFile: ['*.txt']}]}]},
       {any: [{headBranch: ['some-branch']}]}
     ];
     const changedFiles = ['foo.txt', 'bar.md'];
@@ -130,7 +137,7 @@ describe('checkMatchConfigs', () => {
 
     it('returns true when only both config matches', () => {
       const matchConfig: MatchConfig[] = [
-        {any: [{changedFiles: ['*.txt']}]},
+        {any: [{changedFiles: [{AnyGlobToAnyFile: ['*.txt']}]}]},
         {any: [{headBranch: ['head-branch']}]}
       ];
       const result = checkMatchConfigs(changedFiles, matchConfig);

--- a/dist/index.js
+++ b/dist/index.js
@@ -281,12 +281,13 @@ function checkIfAnyGlobMatchesAnyFile(changedFiles, globs) {
     core.debug(`    checking "AnyGlobToAnyFile" config patterns`);
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     for (const matcher of matchers) {
-        for (const changedFile of changedFiles) {
+        const matchedFile = changedFiles.find(changedFile => {
             core.debug(`     checking "${printPattern(matcher)}" pattern against ${changedFile}`);
-            if (matcher.match(changedFile)) {
-                core.debug(`     "${printPattern(matcher)}" pattern matched ${changedFile}`);
-                return true;
-            }
+            return matcher.match(changedFile);
+        });
+        if (matchedFile) {
+            core.debug(`     "${printPattern(matcher)}" pattern matched ${matchedFile}`);
+            return true;
         }
     }
     core.debug(`    none of the patterns matched any of the files`);
@@ -297,19 +298,16 @@ function checkIfAllGlobsMatchAnyFile(changedFiles, globs) {
     core.debug(`    checking "AllGlobsToAnyFile" config patterns`);
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     for (const changedFile of changedFiles) {
-        let matched = true;
-        for (const matcher of matchers) {
+        const mismatchedGlob = matchers.find(matcher => {
             core.debug(`     checking "${printPattern(matcher)}" pattern against ${changedFile}`);
-            if (!matcher.match(changedFile)) {
-                core.debug(`     "${printPattern(matcher)}" pattern  did not match ${changedFile}`);
-                matched = false;
-                break;
-            }
+            return !matcher.match(changedFile);
+        });
+        if (mismatchedGlob) {
+            core.debug(`     "${printPattern(mismatchedGlob)}" pattern did not match ${changedFile}`);
+            continue;
         }
-        if (matched) {
-            core.debug(`    all patterns matched ${changedFile}`);
-            return true;
-        }
+        core.debug(`    all patterns matched ${changedFile}`);
+        return true;
     }
     core.debug(`    none of the files matched all patterns`);
     return false;
@@ -319,19 +317,16 @@ function checkIfAnyGlobMatchesAllFiles(changedFiles, globs) {
     core.debug(`    checking "AnyGlobToAllFiles" config patterns`);
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     for (const matcher of matchers) {
-        let matched = true;
-        for (const changedFile of changedFiles) {
+        const mismatchedFile = changedFiles.find(changedFile => {
             core.debug(`     checking "${printPattern(matcher)}" pattern against ${changedFile}`);
-            if (!matcher.match(changedFile)) {
-                core.debug(`     "${printPattern(matcher)}" pattern did not match ${changedFile}`);
-                matched = false;
-                break;
-            }
+            return !matcher.match(changedFile);
+        });
+        if (mismatchedFile) {
+            core.debug(`     "${printPattern(matcher)}" pattern did not match ${mismatchedFile}`);
+            continue;
         }
-        if (matched) {
-            core.debug(`    "${printPattern(matcher)}" pattern matched all files`);
-            return true;
-        }
+        core.debug(`    "${printPattern(matcher)}" pattern matched all files`);
+        return true;
     }
     core.debug(`    none of the patterns matched all files`);
     return false;
@@ -341,12 +336,13 @@ function checkIfAllGlobsMatchAllFiles(changedFiles, globs) {
     core.debug(`    checking "AllGlobsToAllFiles" config patterns`);
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     for (const changedFile of changedFiles) {
-        for (const matcher of matchers) {
+        const mismatchedGlob = matchers.find(matcher => {
             core.debug(`     checking "${printPattern(matcher)}" pattern against ${changedFile}`);
-            if (!matcher.match(changedFile)) {
-                core.debug(`     "${printPattern(matcher)}" pattern did not match ${changedFile}`);
-                return false;
-            }
+            return !matcher.match(changedFile);
+        });
+        if (mismatchedGlob) {
+            core.debug(`     "${printPattern(mismatchedGlob)}" pattern did not match ${changedFile}`);
+            return false;
         }
     }
     core.debug(`    all patterns matched all files`);

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -3,10 +3,24 @@ import * as github from '@actions/github';
 import {Minimatch} from 'minimatch';
 
 export interface ChangedFilesMatchConfig {
-  changedFiles?: string[];
+  changedFiles?: ChangedFilesGlobPatternsConfig[];
+}
+
+interface ChangedFilesGlobPatternsConfig {
+  AnyGlobToAnyFile?: string[];
+  AnyGlobToAllFiles?: string[];
+  AllGlobsToAnyFile?: string[];
+  AllGlobsToAllFiles?: string[];
 }
 
 type ClientType = ReturnType<typeof github.getOctokit>;
+
+const ALLOWED_FILES_CONFIG_KEYS = [
+  'AnyGlobToAnyFile',
+  'AnyGlobToAllFiles',
+  'AllGlobsToAnyFile',
+  'AllGlobsToAllFiles'
+];
 
 export async function getChangedFiles(
   client: ClientType,
@@ -35,76 +49,300 @@ export function toChangedFilesMatchConfig(
   if (!config['changed-files'] || !config['changed-files'].length) {
     return {};
   }
+  const changedFilesConfigs = Array.isArray(config['changed-files'])
+    ? config['changed-files']
+    : [config['changed-files']];
 
-  const changedFilesConfig = config['changed-files'];
+  const validChangedFilesConfigs: ChangedFilesGlobPatternsConfig[] = [];
+
+  changedFilesConfigs.forEach(changedFilesConfig => {
+    if (!isObject(changedFilesConfig)) {
+      throw new Error(
+        `The "changed-files" section must have a valid config structure. Please read the action documentation for more information`
+      );
+    }
+
+    const changedFilesConfigKeys = Object.keys(changedFilesConfig);
+    const invalidKeys = changedFilesConfigKeys.filter(
+      key => !ALLOWED_FILES_CONFIG_KEYS.includes(key)
+    );
+
+    if (invalidKeys.length) {
+      throw new Error(
+        `Unknown config options were under "changed-files": ${invalidKeys.join(
+          ', '
+        )}`
+      );
+    }
+
+    changedFilesConfigKeys.forEach(key => {
+      validChangedFilesConfigs.push({
+        [key]: Array.isArray(changedFilesConfig[key])
+          ? changedFilesConfig[key]
+          : [changedFilesConfig[key]]
+      });
+    });
+  });
 
   return {
-    changedFiles: Array.isArray(changedFilesConfig)
-      ? changedFilesConfig
-      : [changedFilesConfig]
+    changedFiles: validChangedFilesConfigs
   };
+}
+
+function isObject(obj: any): boolean {
+  return obj !== null && typeof obj === 'object' && !Array.isArray(obj);
 }
 
 function printPattern(matcher: Minimatch): string {
   return (matcher.negate ? '!' : '') + matcher.pattern;
 }
 
-function isAnyMatch(changedFile: string, matchers: Minimatch[]): boolean {
-  core.debug(`    matching patterns against file ${changedFile}`);
-  for (const matcher of matchers) {
-    core.debug(`     - ${printPattern(matcher)}`);
-    if (matcher.match(changedFile)) {
-      core.debug(`    ${printPattern(matcher)} matched`);
-      return true;
-    }
-  }
-
-  core.debug(`    no patterns matched`);
-  return false;
-}
-
-function isAllMatch(changedFile: string, matchers: Minimatch[]): boolean {
-  core.debug(`    matching patterns against file ${changedFile}`);
-  for (const matcher of matchers) {
-    core.debug(`     - ${printPattern(matcher)}`);
-    if (!matcher.match(changedFile)) {
-      core.debug(`    ${printPattern(matcher)} did not match`);
-      return false;
-    }
-  }
-
-  core.debug(`    all patterns matched`);
-  return true;
-}
-
 export function checkAnyChangedFiles(
   changedFiles: string[],
-  globs: string[]
+  globPatternsConfigs: ChangedFilesGlobPatternsConfig[]
 ): boolean {
-  const matchers = globs.map(g => new Minimatch(g));
-  for (const changedFile of changedFiles) {
-    if (isAnyMatch(changedFile, matchers)) {
-      core.debug(`   "any" patterns matched against ${changedFile}`);
-      return true;
+  core.debug(`   checking "changed-files" patterns`);
+
+  for (const globPatternsConfig of globPatternsConfigs) {
+    if (globPatternsConfig.AnyGlobToAnyFile) {
+      if (
+        checkIfAnyGlobMatchesAnyFile(
+          changedFiles,
+          globPatternsConfig.AnyGlobToAnyFile
+        )
+      ) {
+        core.debug(`   "changed-files" matched`);
+        return true;
+      }
+    }
+
+    if (globPatternsConfig.AnyGlobToAllFiles) {
+      if (
+        checkIfAnyGlobMatchesAllFiles(
+          changedFiles,
+          globPatternsConfig.AnyGlobToAllFiles
+        )
+      ) {
+        core.debug(`   "changed-files" matched`);
+        return true;
+      }
+    }
+
+    if (globPatternsConfig.AllGlobsToAnyFile) {
+      if (
+        checkIfAllGlobsMatchAnyFile(
+          changedFiles,
+          globPatternsConfig.AllGlobsToAnyFile
+        )
+      ) {
+        core.debug(`   "changed-files" matched`);
+        return true;
+      }
+    }
+
+    if (globPatternsConfig.AllGlobsToAllFiles) {
+      if (
+        checkIfAllGlobsMatchAllFiles(
+          changedFiles,
+          globPatternsConfig.AllGlobsToAllFiles
+        )
+      ) {
+        core.debug(`   "changed-files" matched`);
+        return true;
+      }
     }
   }
 
-  core.debug(`   "any" patterns did not match any files`);
+  core.debug(`   "changed-files" did not match`);
   return false;
 }
 
 export function checkAllChangedFiles(
   changedFiles: string[],
-  globs: string[]
+  globPatternsConfigs: ChangedFilesGlobPatternsConfig[]
 ): boolean {
-  const matchers = globs.map(g => new Minimatch(g));
-  for (const changedFile of changedFiles) {
-    if (!isAllMatch(changedFile, matchers)) {
-      core.debug(`   "all" patterns did not match against ${changedFile}`);
-      return false;
+  core.debug(`   checking "changed-files" patterns`);
+
+  for (const globPatternsConfig of globPatternsConfigs) {
+    if (globPatternsConfig.AnyGlobToAnyFile) {
+      if (
+        !checkIfAnyGlobMatchesAnyFile(
+          changedFiles,
+          globPatternsConfig.AnyGlobToAnyFile
+        )
+      ) {
+        core.debug(`   "changed-files" did not match`);
+        return false;
+      }
+    }
+
+    if (globPatternsConfig.AnyGlobToAllFiles) {
+      if (
+        !checkIfAnyGlobMatchesAllFiles(
+          changedFiles,
+          globPatternsConfig.AnyGlobToAllFiles
+        )
+      ) {
+        core.debug(`   "changed-files" did not match`);
+        return false;
+      }
+    }
+
+    if (globPatternsConfig.AllGlobsToAnyFile) {
+      if (
+        !checkIfAllGlobsMatchAnyFile(
+          changedFiles,
+          globPatternsConfig.AllGlobsToAnyFile
+        )
+      ) {
+        core.debug(`   "changed-files" did not match`);
+        return false;
+      }
+    }
+
+    if (globPatternsConfig.AllGlobsToAllFiles) {
+      if (
+        !checkIfAllGlobsMatchAllFiles(
+          changedFiles,
+          globPatternsConfig.AllGlobsToAllFiles
+        )
+      ) {
+        core.debug(`   "changed-files" did not match`);
+        return false;
+      }
     }
   }
 
-  core.debug(`   "all" patterns matched all files`);
+  core.debug(`   "changed-files" patterns matched`);
+  return true;
+}
+
+export function checkIfAnyGlobMatchesAnyFile(
+  changedFiles: string[],
+  globs: string[]
+): boolean {
+  core.debug(`    checking "AnyGlobToAnyFile" config patterns`);
+  const matchers = globs.map(g => new Minimatch(g));
+
+  for (const matcher of matchers) {
+    for (const changedFile of changedFiles) {
+      core.debug(
+        `     checking "${printPattern(
+          matcher
+        )}" pattern against ${changedFile}`
+      );
+
+      if (matcher.match(changedFile)) {
+        core.debug(
+          `     "${printPattern(matcher)}" pattern matched ${changedFile}`
+        );
+        return true;
+      }
+    }
+  }
+
+  core.debug(`    none of the patterns matched any of the files`);
+  return false;
+}
+
+export function checkIfAllGlobsMatchAnyFile(
+  changedFiles: string[],
+  globs: string[]
+): boolean {
+  core.debug(`    checking "AllGlobsToAnyFile" config patterns`);
+  const matchers = globs.map(g => new Minimatch(g));
+
+  for (const changedFile of changedFiles) {
+    let matched = true;
+
+    for (const matcher of matchers) {
+      core.debug(
+        `     checking "${printPattern(
+          matcher
+        )}" pattern against ${changedFile}`
+      );
+
+      if (!matcher.match(changedFile)) {
+        core.debug(
+          `     "${printPattern(
+            matcher
+          )}" pattern  did not match ${changedFile}`
+        );
+        matched = false;
+        break;
+      }
+    }
+
+    if (matched) {
+      core.debug(`    all patterns matched ${changedFile}`);
+      return true;
+    }
+  }
+
+  core.debug(`    none of the files matched all patterns`);
+  return false;
+}
+
+export function checkIfAnyGlobMatchesAllFiles(
+  changedFiles: string[],
+  globs: string[]
+): boolean {
+  core.debug(`    checking "AnyGlobToAllFiles" config patterns`);
+  const matchers = globs.map(g => new Minimatch(g));
+
+  for (const matcher of matchers) {
+    let matched = true;
+
+    for (const changedFile of changedFiles) {
+      core.debug(
+        `     checking "${printPattern(
+          matcher
+        )}" pattern against ${changedFile}`
+      );
+
+      if (!matcher.match(changedFile)) {
+        core.debug(
+          `     "${printPattern(matcher)}" pattern did not match ${changedFile}`
+        );
+        matched = false;
+        break;
+      }
+    }
+
+    if (matched) {
+      core.debug(`    "${printPattern(matcher)}" pattern matched all files`);
+      return true;
+    }
+  }
+
+  core.debug(`    none of the patterns matched all files`);
+  return false;
+}
+
+export function checkIfAllGlobsMatchAllFiles(
+  changedFiles: string[],
+  globs: string[]
+): boolean {
+  core.debug(`    checking "AllGlobsToAllFiles" config patterns`);
+  const matchers = globs.map(g => new Minimatch(g));
+
+  for (const changedFile of changedFiles) {
+    for (const matcher of matchers) {
+      core.debug(
+        `     checking "${printPattern(
+          matcher
+        )}" pattern against ${changedFile}`
+      );
+
+      if (!matcher.match(changedFile)) {
+        core.debug(
+          `     "${printPattern(matcher)}" pattern did not match ${changedFile}`
+        );
+        return false;
+      }
+    }
+  }
+
+  core.debug(`    all patterns matched all files`);
   return true;
 }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -236,18 +236,21 @@ export function checkAny(
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
       if (checkAnyBranch(matchConfig.baseBranch, 'base')) {
+        core.debug(`  "any" patterns matched`);
         return true;
       }
     }
 
     if (matchConfig.changedFiles) {
       if (checkAnyChangedFiles(changedFiles, matchConfig.changedFiles)) {
+        core.debug(`  "any" patterns matched`);
         return true;
       }
     }
 
     if (matchConfig.headBranch) {
       if (checkAnyBranch(matchConfig.headBranch, 'head')) {
+        core.debug(`  "any" patterns matched`);
         return true;
       }
     }
@@ -274,6 +277,7 @@ export function checkAll(
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
       if (!checkAllBranch(matchConfig.baseBranch, 'base')) {
+        core.debug(`  "all" patterns did not match`);
         return false;
       }
     }
@@ -285,12 +289,14 @@ export function checkAll(
       }
 
       if (!checkAllChangedFiles(changedFiles, matchConfig.changedFiles)) {
+        core.debug(`  "all" patterns did not match`);
         return false;
       }
     }
 
     if (matchConfig.headBranch) {
       if (!checkAllBranch(matchConfig.headBranch, 'head')) {
+        core.debug(`  "all" patterns did not match`);
         return false;
       }
     }


### PR DESCRIPTION
**Description:**
In scope of this pull request, the structure of the configuration file (`.github/labeler.yml`) was changed from
```yml
LabelName:
- any:
  - changed-files: ['list', 'of', 'globs']
  - base-branch: ['list', 'of', 'regexps']
  - head-branch: ['list', 'of', 'regexps']
- all:
  - changed-files: ['list', 'of', 'globs']
  - base-branch: ['list', 'of', 'regexps']
  - head-branch: ['list', 'of', 'regexps']
```
to
```yml
LabelName:
- any:
  - changed-files: 
    - AnyGlobToAnyFile: ['list', 'of', 'globs']
    - AnyGlobToAllFiles: ['list', 'of', 'globs']
    - AllGlobsToAnyFile: ['list', 'of', 'globs']
    - AllGlobsToAllFiles: ['list', 'of', 'globs']
  - base-branch: ['list', 'of', 'regexps']
  - head-branch: ['list', 'of', 'regexps']
- all:
  - changed-files:
    - AnyGlobToAnyFile: ['list', 'of', 'globs']
    - AnyGlobToAllFiles: ['list', 'of', 'globs']
    - AllGlobsToAnyFile: ['list', 'of', 'globs']
    - AllGlobsToAllFiles: ['list', 'of', 'globs']
  - base-branch: ['list', 'of', 'regexps']
  - head-branch: ['list', 'of', 'regexps']
```

In the previous implementation of the beta version, customers had two options: `any` (ANY glob must match against ANY changed file) and `all` (ALL globs must match against ALL changed files). In scope of this PR, we expanded this functionality and provided customers with all possible combinations:
1) `AnyGlobToAnyFile` - ANY glob must match against ANY changed file
2) `AllGlobsToAnyFile` - ALL globs must match against ANY changed file
3) `AnyGlobToAllFiles` - ANY glob must match against ALL changed files
4) `AllGlobsToAllFiles` - ALL globs must match against ALL changed files

Please find more details about the previous implementation in the [release notes](https://github.com/actions/labeler/releases/tag/v5.0.0-alpha.1) 